### PR TITLE
チュートリアル用クラスタを1.21にアップグレードする

### DIFF
--- a/echo-server/main.yaml
+++ b/echo-server/main.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   namespace: default
@@ -10,9 +10,12 @@ spec:
   - host: echo.lvh.me
     http:
       paths:
-      - backend:
-          serviceName: echo-server
-          servicePort: http
+      - pathType: ImplementationSpecific
+        backend:
+          service:
+            name: echo-server
+            port:
+              name: http
 
 ---
 apiVersion: v1

--- a/k8s-2048/ingress.yaml
+++ b/k8s-2048/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   # k8s-2048 Namespaceに作成されるように指定する
@@ -18,8 +18,11 @@ spec:
       paths:
       # Ingressが指定したホスト名でリクエストがきた場合に、
       # どのサービスのどのポートへリクエストを投げるのか指定する
-      - backend:
-          # Service名　
-          serviceName: k8s-2048
-          # Serviceで公開したポート番号か、nameを指定する
-          servicePort: http
+      - pathType: ImplementationSpecific
+        backend:
+          service:
+            # Service名　
+            name: k8s-2048
+            # Serviceで公開したポート名を指定する
+            port:
+              name: http

--- a/kindconfig.yaml
+++ b/kindconfig.yaml
@@ -1,16 +1,16 @@
+---
 # https://kind.sigs.k8s.io/docs/user/configuration/
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
-  image: kindest/node:v1.18.19@sha256:530378628c7c518503ade70b1df698b5de5585dcdba4f349328d986b8849b1ee
+  image: kindest/node:v1.21.1@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6
   kubeadmConfigPatches:
   - |
     kind: InitConfiguration
     nodeRegistration:
       kubeletExtraArgs:
         node-labels: 'ingress-ready=true'
-        authorization-mode: 'AlwaysAllow'
   extraPortMappings:
   - containerPort: 80
     hostPort: 80


### PR DESCRIPTION
## 概要

スタディストのk8s研修で使っているチュートリアル用クラスタを1.21にアップグレードする。
このアップグレードに伴い、1.22から廃止予定の`networking.k8s.io/v1beta1`のIngressリソースを`networking.k8s.io/v1`のに変更している。