### PR TITLE
Support arm64

### DIFF
--- a/echo-server/main.yaml
+++ b/echo-server/main.yaml
@@ -51,8 +51,6 @@ spec:
       containers:
       - name: echo-server
         image: ealen/echo-server
-        args:
-        - -text="hello world"
         ports:
         - name: http
           containerPort: 80

--- a/echo-server/main.yaml
+++ b/echo-server/main.yaml
@@ -50,10 +50,10 @@ spec:
     spec:
       containers:
       - name: echo-server
-        image: hashicorp/http-echo
+        image: ealen/echo-server
         args:
         - -text="hello world"
         ports:
         - name: http
-          containerPort: 5678
+          containerPort: 80
           protocol: TCP


### PR DESCRIPTION
# 背景

M1 Macでkindを使ってcluster作成するとnodeがarm64で作成される
```
$ k describe node k8s-tutorial-control-plane | grep Architecture
  Architecture:               arm64
```

そのため arm64 imageが配信されていない hashicorp/http-echo だとコンテナ起動時にエラーになる
```
runtime: failed to create new OS thread (have 2 already; errno=22)
fatal error: newosproc
```

# やったこと
ダウンロード数も多い https://hub.docker.com/r/ealen/echo-server を使用するように修正した。
hashicorpと違って`VERIFIED PUBLISHER` ではないので若干心配だがローカルだから大丈夫かなという気持ち。
